### PR TITLE
adding dockerfile and singularity recipes for containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Containers
+*.sif
+
 # Distribution / packaging
 .Python
 build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.7
+
+# docker build -t trumpbot .
+
+RUN apt-get update && \
+    apt-get install -y python-numpy && \
+    mkdir -p /code
+
+ADD . /code
+WORKDIR /code
+RUN pip install -r requirements.txt
+
+ENTRYPOINT ["python"]
+CMD ["/code/trumpbot.py"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,56 @@
 # Trumpbot v1.0
 Trumpbot was my attempt at creating a RNN trained on Donald Trumps(DT) tweets. I used this as a sort of practice project for learning a bit about RNN's and Tensorflow 2. The result was a chaos and a learning experience so lets dive in.
 
+## Run with Containers
+
+### Docker
+
+If you don't want to install dependencies to your host, you can build a Docker container
+with the included Dockerfile:
+
+```bash
+$ docker build -t trumpbot .
+```
+
+The entrypoint is the script to generate the tweets:
+
+```bash
+$ docker run trumpbot
+...
+ obamas Top and France at 900 PM on FoxNews. Anderson Congratulations to the House vote for MittRomney o
+
+ hillary Clinton has been a total disaster. I have an idea for her great speech on CNN in the world  a great honor for me and his partisan hotel and every spor
+
+ friends support Trump International Golf Club on the Paris About that Right School is started by the DNC and Clinton and the DNC that will be a great show with t
+```
+
+If you want to interact with the container (perhaps training first) you can shell inside instead:
+
+```bash
+$ docker run -it --entrypoint bash trumpbot
+root@b53b98f12c34:/code# ls
+Dockerfile  README.md  __init__.py  learn.py  raw_tweets.txt  requirements.txt	training_checkpoints  trumpbot.py  tweets.txt
+```
+
+You'll be in the `/code` directory that contains the source code. 
+
+### Singularity
+
+For users that want to perhaps use GPU (or better leverage the host) the recommendation is to
+use a [Singularity](https://www.sylabs.io/guides/3.2/user-guide/) container, and a recipe file [Singularity](Singularity) is provided
+to build the container.
+
+```bash
+$ sudo singularity build trumpbot.sif Singularity
+```
+
+And then to run (add the --nv flag if you want to leverage any host libraries).
+
+```bash
+$ singularity run trumpbot.sif
+```
+
+If you need to change the way that tensorflow or numpy are installed, you can edit the Singularity or Docker recipes.
 
 ## Setup
 Setup is pretty straightforward. It only needs numpy and tensorflow 2 alpha just run the start pip install:

--- a/Singularity
+++ b/Singularity
@@ -1,0 +1,20 @@
+Bootstrap: docker
+From: python:3.7
+
+# sudo singularity build trumpbot.sif Singularity
+
+%setup
+    echo "Adding code to container."
+    mkdir -p "${SINGULARITY_ROOTFS}/code"
+    cp -R . "${SINGULARITY_ROOTFS}/code"
+
+%post
+apt-get update && \
+    apt-get install -y python-numpy && \
+    mkdir -p /code
+
+cd /code
+pip install -r requirements.txt
+
+%runscript
+    exec python /code/trumpbot.py "$@"


### PR DESCRIPTION
This pull request will add container recipes (Docker and Singularity, respectively) to instruct the user how to generate the trumpbot in a container. This is helpful in case the user doesn't want to install or develop on his/her host, or to preserve a (working) version of the model with a particular version of dependencies.
It's fairly common that as tensorflow (or any ML library) is developed, older models become less and less likely to work. Containers can help with that :)

The instructions for building and running are included in the README, and I've also pushed a container to Docker Hub for you to use more quickly:

```bash
$ docker run vanessa/trumpbot
```
This will hopefully help to make development or use easy! If you have a Docker account, you could provide the container as an automated build from the Dockerfile (I didn't add this to the README thinking you might).

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>